### PR TITLE
Saving only failed tests

### DIFF
--- a/README
+++ b/README
@@ -19,13 +19,19 @@ Once the plugin is installed edit your `conftest.py` and insert in the top of th
 
     pytest_plugins = 'pytest_session2file'
 
-Then you can launch your test with the new option `--session2file=` like this :
+Then you can launch your test with one of the two options as follows:
 
     py.test --session2file=FILENAME
+    py.test --failure2file=FILENAME
+    py.test --session2file=FILENAME --failure2file=FILENAME
 
-If you don't want to edit your `conftest.py` you can invoque py.test like this :
+* In case both paths provided, the plugin will store the entire pytest session.
+
+If you don't want to edit your `conftest.py` you can invoke py.test like this:
 
     py.test -p pytest_session2file --session2file=FILENAME
+    py.test -p pytest_session2file --failure2file=FILENAME
+    py.test -p pytest_session2file --session2file=FILENAME --failure2file=FILENAME
 
 At the end of the test execution you should obtain a text file with the content of stdout of py.test under the filename
 provided that look like this :
@@ -48,11 +54,10 @@ provided that look like this :
 
 **Platforms:** All
 
-**Version:** 0.1.11
+**Version:** 0.1.12
 
 **Date:** 2021-01-26 13:08:31
 
 **License:** LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
 
 Copyright (C) 2015 Richard Vézina <ml.richard.vezinar@gmail.com>
-

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 pytest-session2file
 ======================
 
-pytest-session2file is a py.test plugin that save failure or test session information to a file pass that can be
+pytest-session2file is a py.test plugin that save failures or test session information to a file pass that can be
 invoked as at command line when launching py.test run. It put in a file exactly what pytest return to stdout.
 
 **Installation**
@@ -19,13 +19,15 @@ Once the plugin is installed edit your `conftest.py` and insert in the top of th
 
     pytest_plugins = 'pytest_session2file'
 
-Then you can launch your test with the new option `--session2file=` like this :
+Then you can launch your test with one of the two options as follows:
 
     py.test --session2file=FILENAME
+    py.test --session2file=FILENAME --failures-only
 
-If you don't want to edit your `conftest.py` you can invoque py.test like this :
+If you don't want to edit your `conftest.py` you can invoke py.test like this:
 
     py.test -p pytest_session2file --session2file=FILENAME
+    py.test -p pytest_session2file --session2file=FILENAME --failures-only
 
 At the end of the test execution you should obtain a text file with the content of stdout of py.test under the filename
 provided that look like this :
@@ -48,11 +50,10 @@ provided that look like this :
 
 **Platforms:** All
 
-**Version:** 0.1.11
+**Version:** 0.1.12
 
 **Date:** 2021-01-26 13:08:31
 
 **License:** LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
 
 Copyright (C) 2015 Richard Vézina <ml.richard.vezinar@gmail.com>
-

--- a/README.md
+++ b/README.md
@@ -19,13 +19,19 @@ Once the plugin is installed edit your `conftest.py` and insert in the top of th
 
     pytest_plugins = 'pytest_session2file'
 
-Then you can launch your test with the new option `--session2file=` like this :
+Then you can launch your test with one of the two options as follows:
 
     py.test --session2file=FILENAME
+    py.test --failure2file=FILENAME
+    py.test --session2file=FILENAME --failure2file=FILENAME
 
-If you don't want to edit your `conftest.py` you can invoque py.test like this :
+* In case both paths provided, the plugin will store the entire pytest session.
+
+If you don't want to edit your `conftest.py` you can invoke py.test like this:
 
     py.test -p pytest_session2file --session2file=FILENAME
+    py.test -p pytest_session2file --failure2file=FILENAME
+    py.test -p pytest_session2file --session2file=FILENAME --failure2file=FILENAME
 
 At the end of the test execution you should obtain a text file with the content of stdout of py.test under the filename
 provided that look like this :
@@ -48,11 +54,10 @@ provided that look like this :
 
 **Platforms:** All
 
-**Version:** 0.1.11
+**Version:** 0.1.12
 
 **Date:** 2021-01-26 13:08:31
 
 **License:** LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
 
 Copyright (C) 2015 Richard Vézina <ml.richard.vezinar@gmail.com>
-

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 pytest-session2file
 ======================
 
-pytest-session2file is a py.test plugin that save failure or test session information to a file pass that can be
+pytest-session2file is a py.test plugin that save failures or test session information to a file pass that can be
 invoked as at command line when launching py.test run. It put in a file exactly what pytest return to stdout.
 
 **Installation**
-
 
 Install it with pip as follows :
 
@@ -19,13 +18,15 @@ Once the plugin is installed edit your `conftest.py` and insert in the top of th
 
     pytest_plugins = 'pytest_session2file'
 
-Then you can launch your test with the new option `--session2file=` like this :
+Then you can launch your test with one of the two options as follows:
 
     py.test --session2file=FILENAME
+    py.test --session2file=FILENAME --failures-only
 
-If you don't want to edit your `conftest.py` you can invoke py.test like this :
+If you don't want to edit your `conftest.py` you can invoke py.test like this:
 
     py.test -p pytest_session2file --session2file=FILENAME
+    py.test -p pytest_session2file --session2file=FILENAME --failures-only
 
 At the end of the test execution you should obtain a text file with the content of stdout of py.test under the filename
 provided that look like this :
@@ -48,11 +49,10 @@ provided that look like this :
 
 **Platforms:** All
 
-**Version:** 0.1.11
+**Version:** 0.1.12
 
 **Date:** 2021-01-26 13:08:31
 
 **License:** LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
 
 Copyright (C) 2015 Richard Vézina <ml.richard.vezinar@gmail.com>
-

--- a/pytest_session2file/pytest_session2file.py
+++ b/pytest_session2file/pytest_session2file.py
@@ -4,19 +4,20 @@
 """
 Pytest Plugin that save failure or test session information to a file pass as a command line argument to pytest.
 
-It put in a file exactly what pytest return to the stdout.
+It put in a file exactly what pytest return to the stdout, depends on the flad provided.
 
 To use it :
 Put this file in the root of tests/ edit your conftest and insert in the top of the file :
 
     pytest_plugins = 'pytest_session2file'
 
-Then you can launch your test with the new option --session2file= like this :
+Then you can launch your test with one of the two options as follows:
 
     py.test --session2file=FILENAME
-Or :
-    py.test -p pytest_session2file --session2file=FILENAME
+    py.test --failure2file=FILENAME
+    py.test --session2file=FILENAME --failure2file=FILENAME
 
+* In case both paths provided, the plugin will store the entire pytest session.
 
 Inspire by _pytest.pastebin
 Ref: https://github.com/pytest-dev/pytest/blob/master/_pytest/pastebin.py
@@ -26,17 +27,22 @@ Date : 2016-03-16 12:35:41
 Copyright (C) 2015 Richard Vézina <ml.richard.vezinar @ gmail.com>
 License: LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
 """
-
-import pytest
+import re
 import sys
 import tempfile
+
+import pytest
+
+
+FAILURES_PATTERN = "=+ FAILURES =+"
 
 
 def pytest_addoption(parser):
     group = parser.getgroup("terminal reporting")
     group._addoption('--session2file', action='store', metavar='path', default=None,
                      help="Save to file the pytest session information")
-    return
+    group._addoption('--failure2file', action='store', metavar='path', default=None,
+                     help="Save to file only failed tests from pytest session")
 
 
 @pytest.hookimpl(trylast=True)
@@ -56,7 +62,6 @@ def pytest_configure(config):
             else:
                 config._pytestsessionfile.write(s.encode('utf8'))
         tr._tw.write = tee_write
-    return
 
 
 def pytest_unconfigure(config):
@@ -71,17 +76,23 @@ def pytest_unconfigure(config):
         del tr._tw.__dict__['write']
         # write summary
         create_new_file(config=config, contents=sessionlog)
-    return
 
 
 def create_new_file(config, contents):
     """
-    Creates a new file with pytest session contents.
+    Creates a new file with pytest session contents, depends on the flag.
     :contents: pytest stdout contents
     """
-    path = config.option.session2file
+    path=config.option.session2file
+    failure_path=config.option.failure2file
+    # handle failed tests only
+    if failure_path is not None:
+        with open(failure_path, 'w') as f:
+            failure_pattern = re.compile(FAILURES_PATTERN)
+            m_obj=re.search(failure_pattern, contents)
+            if m_obj is not None:
+                f.writelines(contents[m_obj.start():])
+    # handle all tests
     if path is not None:
         with open(path, 'w') as f:
             f.writelines(contents)
-    return
-

--- a/pytest_session2file/pytest_session2file.py
+++ b/pytest_session2file/pytest_session2file.py
@@ -2,21 +2,19 @@
 # -*- coding: utf-8 -*-
 
 """
-Pytest Plugin that save failure or test session information to a file pass as a command line argument to pytest.
+Pytest Plugin that saves failures or test session information to a file pass as a command line argument to pytest.
 
-It put in a file exactly what pytest return to the stdout.
+It put in a file exactly what pytest return to the stdout, depends on the flag provided.
 
 To use it :
 Put this file in the root of tests/ edit your conftest and insert in the top of the file :
 
     pytest_plugins = 'pytest_session2file'
 
-Then you can launch your test with the new option --session2file= like this :
+Then you can launch your test with one of the two options as follows:
 
     py.test --session2file=FILENAME
-Or :
-    py.test -p pytest_session2file --session2file=FILENAME
-
+    py.test --session2file=FILENAME --failures-only
 
 Inspire by _pytest.pastebin
 Ref: https://github.com/pytest-dev/pytest/blob/master/_pytest/pastebin.py
@@ -26,17 +24,22 @@ Date : 2016-03-16 12:35:41
 Copyright (C) 2015 Richard Vézina <ml.richard.vezinar @ gmail.com>
 License: LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
 """
-
-import pytest
+import re
 import sys
 import tempfile
+
+import pytest
+
+
+FAILURES_PATTERN = "=+ FAILURES =+"
 
 
 def pytest_addoption(parser):
     group = parser.getgroup("terminal reporting")
     group._addoption('--session2file', action='store', metavar='path', default=None,
                      help="Save to file the pytest session information")
-    return
+    group._addoption('--failures-only', action='store_true', default=False,
+                     help="Save to file only failed tests from pytest session")
 
 
 @pytest.hookimpl(trylast=True)
@@ -56,7 +59,6 @@ def pytest_configure(config):
             else:
                 config._pytestsessionfile.write(s.encode('utf8'))
         tr._tw.write = tee_write
-    return
 
 
 def pytest_unconfigure(config):
@@ -71,17 +73,25 @@ def pytest_unconfigure(config):
         del tr._tw.__dict__['write']
         # write summary
         create_new_file(config=config, contents=sessionlog)
-    return
 
 
 def create_new_file(config, contents):
     """
-    Creates a new file with pytest session contents.
+    Creates a new file with pytest session contents, depends on the flag.
     :contents: pytest stdout contents
     """
-    path = config.option.session2file
+    path=config.option.session2file
+    only_failures=config.option.failures_only
+
+    # keep full session information as default
+    session2file_content = contents
     if path is not None:
         with open(path, 'w') as f:
-            f.writelines(contents)
-    return
-
+            # handle failed tests only
+            if only_failures:
+                failure_pattern = re.compile(FAILURES_PATTERN)
+                m_obj=re.search(failure_pattern, contents)
+                if m_obj is not None:
+                    session2file_content=contents[m_obj.start():]
+            # write chosen information
+            f.writelines(session2file_content)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,11 @@ if os.path.exists('README.md'):
 
 setup(
     name="pytest-session2file",
-    version='0.1.11',
+    version='0.1.12',
     author='Richard Vézina',
     author_email='ml.richard.vezina@gmail.com',
+    maintainer='Harel Keres',
+    maintainer_email='keresh3@gmail.com',
     license='LGPLv3 (http://www.gnu.org/licenses/lgpl.html)',
     packages=[],
     py_modules=['pytest_session2file.pytest_session2file'],
@@ -40,5 +42,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.10'
     ],
 )


### PR DESCRIPTION
Adding the option to save only failures by running:
```python
py.test --failure2file=FILENAME
```
OR save both:
```python
py.test -p pytest_session2file --session2file=FILENAME --failure2file=FILENAME
```